### PR TITLE
Fix Order and Cart relation issues, add shipping fee column, and unify field naming

### DIFF
--- a/entities/Cart.js
+++ b/entities/Cart.js
@@ -43,7 +43,7 @@ module.exports = new EntitySchema({
       }
     },
     User: {
-      type: 'many-to-one',
+      type: 'one-to-one',
       target: 'User',
       joinColumn: {
         name: 'user_id',

--- a/entities/Order.js
+++ b/entities/Order.js
@@ -13,7 +13,8 @@ module.exports = new EntitySchema({
     display_id: {
       type: 'varchar',
       length: 14,
-      nullable: false
+      nullable: false,
+      unique: true,
     },
     user_id: {
       type: 'uuid',

--- a/entities/Order.js
+++ b/entities/Order.js
@@ -37,6 +37,10 @@ module.exports = new EntitySchema({
     discount_id: {
       type: 'smallint',
     },
+    shipping_fee: {
+      type: 'integer',
+      nullable: false
+    },
     total_price: {
       type: 'integer',
       nullable: false

--- a/entities/Receiver.js
+++ b/entities/Receiver.js
@@ -19,6 +19,11 @@ module.exports = new EntitySchema({
       length: 10,
       nullable: false
     },
+    post_code: {
+      type: 'varchar',
+      length: 6,
+      nullable: false
+    },
     address: {
       type: 'varchar',
       length: 320,


### PR DESCRIPTION
This PR includes the following updates and fixes:

- fix: Set display_id in the Order entity to unique to prevent duplication
- fix: Changed the relationship between Cart and User from many-to-one to one-to-one to reflect the correct data model
- add: Added a new ship_fee column to the Order entity for storing shipping fees
- fix: Renamed postCode to post_code to follow consistent naming conventions