### PR TITLE
FIX: Add user role to login response

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -165,6 +165,7 @@ const usersController = {
           token,
           user: {
             name: existingUser.name,
+            role: existingUser.role,
           },
         },
       });
@@ -306,10 +307,10 @@ const usersController = {
       const receiverRepository = dataSource.getRepository('Receiver');
       const findUser = await receiverRepository.findOne({
         select: ['name', 'phone', 'post_code', 'address'],
-        where: { id }
+        where: { id },
       });
       res.status(200).json({
-        data: findUser
+        data: findUser,
       });
     } catch (error) {
       logger.error('取得收件資訊錯誤:', error);
@@ -439,4 +440,3 @@ const usersController = {
 };
 
 module.exports = usersController;
-


### PR DESCRIPTION
## Changes Made
- Added user role information to the login response data
- Fixed code formatting in receiver information endpoint
- Removed trailing empty line

## Why
- Including the user role in the login response is necessary for proper user authorization on the client side
- The role information is required for determining user permissions and access control

## Testing
- [x] Login endpoint returns the user role correctly
- [x] Existing functionality remains unchanged
- [x] Receiver information endpoint works as expected

## Related Issues
- Resolves the missing role information in login response