### PR TITLE
feat(Orders): Implement a secure checkout endpoint

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -20,6 +20,7 @@ router.get('/membership/receiver', auth, handleErrorAsync(usersController.getRec
 router.patch('/forget', limiter, handleErrorAsync(usersController.patchForget));
 router.patch('/reset-password', handleErrorAsync(usersController.patchResetPassword));
 router.get('/membership/orders', auth, handleErrorAsync(usersController.getUserOrders));
+router.put('/checkout', auth, handleErrorAsync(usersController.putCheckout));
 router.get('/membership/:order_id', auth, handleErrorAsync(usersController.getUserOrderDetail));
 
 module.exports = router;


### PR DESCRIPTION
## What
This PR introduces the `PUT /checkout` endpoint, which allows an authenticated user to finalize their order by selecting a payment method.

## Key Changes
- **New Endpoint**: Implements `PUT /api/users/checkout`.
- **Ownership Verification**: The endpoint securely validates that the order belongs to the authenticated user by checking both the `orderId` and `userId`.
- **Status Check**: Prevents users from attempting to check out an order that has already been paid for.
- **Updates Payment Method**: Sets the `payment_method_id` on the order record.

## How to Test
1. Create an order and get its ID.
2. Send a `PUT` request to `/api/users/checkout`.
3. Include the `id` (order ID) and `payment_method_id` in the request body.
4. Ensure you are authenticated (provide a JWT token).
5. **Expected Result**: The API should return a `200 OK` status, and the order's `payment_method_id` should be updated in the database.