### PR TITLE
FEAT: Implement user receiver information management

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -17,6 +17,7 @@ router.post('/login', handleErrorAsync(usersController.postLogin));
 router.get('/membership/profile', auth, handleErrorAsync(usersController.getProfile));
 router.put('/membership/profile', auth, handleErrorAsync(usersController.putProfile));
 router.get('/membership/receiver', auth, handleErrorAsync(usersController.getReceiver));
+router.post('/membership/receiver', auth, handleErrorAsync(usersController.postReceiver));
 router.get('/membership/cart', auth, handleErrorAsync(usersController.getCart));
 router.post('/membership/cart', auth, handleErrorAsync(usersController.addToCart));
 router.patch('/forget', limiter, handleErrorAsync(usersController.patchForget));


### PR DESCRIPTION
## Summary

This pull request introduces comprehensive functionality for users to manage their default receiver (shipping) information. It adds a new endpoint to create or update these details and fixes the existing endpoint for retrieving them, ensuring a robust and correct implementation.

### Key Changes

1.  **✨ New Endpoint: `POST /users/receiver` (Create/Update)**
    *   A new method, `postReceiver`, has been added to the `usersController`.
    *   It implements an **upsert** (Update or Insert) logic:
        *   If the user does not have existing receiver information, a new `Receiver` record is created and linked to the user.
        *   If receiver information already exists, it is updated with the new data provided in the request body.
    *   The API response now includes the full `Receiver` object after a successful operation, providing the client with immediate access to the latest data (including the `id` and `updated_at` timestamps).

2.  **🐛 Fixed Endpoint: `GET /users/receiver` (Read)**
    *   The logic in the `getReceiver` method has been completely refactored for correctness.
    *   The previous implementation incorrectly queried the `Receiver` table directly.
    *   The corrected implementation now properly queries the `User` entity and uses the TypeORM `relations` option to fetch the associated `Receiver` data.
    *   It also correctly handles the case where a user has not yet set up their receiver information, returning a clear message and `null` data.

### How to Test

You can verify the functionality using an API client like Postman or Insomnia.

1.  **Initial State (No Receiver Info):**
    *   Make a `GET` request to `/users/receiver`.
    *   **Expected:** Receive a `200 OK` status with a message like "尚無收件人資訊" (No receiver information yet) and `data: null`.

2.  **Create Receiver Info (First Time):**
    *   Make a `POST` request to `/users/receiver` with a JSON body:
        ```json
        {
          "name": "Leo Chou",
          "phone": "0912345678",
          "post_code": "100",
          "address": "Rocket Street No. 1"
        }
        ```
    *   **Expected:** Receive a `201 Created` status, and the response `data` should contain the full receiver object, including a new `id`.

3.  **Update Receiver Info:**
    *   Make another `POST` request to `/users/receiver` with different data:
        ```json
        {
          "name": "Leo Chou",
          "phone": "0987654321",
          "post_code": "110",
          "address": "Gemini Avenue No. 2"
        }
        ```
    *   **Expected:** Receive a `200 OK` status, and the `data` should show the updated information.

4.  **Verify Update with GET:**
    *   Make a final `GET` request to `/users/receiver`.
    *   **Expected:** The `data` in the response should match the updated information from the previous step.