### PR TITLE
FEAT: Implement endpoint to fetch checkout data

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -25,6 +25,7 @@ router.patch('/reset-password', handleErrorAsync(usersController.patchResetPassw
 router.get('/orderReview', auth, handleErrorAsync(usersController.getOrderReview));
 router.post('/membership/order', auth, handleErrorAsync(usersController.postCreateOrder));
 router.get('/membership/orders', auth, handleErrorAsync(usersController.getUserOrders));
+router.get('/checkout', auth, handleErrorAsync(usersController.getCheckout));
 router.put('/checkout', auth, handleErrorAsync(usersController.putCheckout));
 router.get('/discount', auth, handleErrorAsync(usersController.getDiscount));
 router.get('/orderReview', auth, handleErrorAsync(usersController.getOrderReview));


### PR DESCRIPTION
## Summary

This pull request introduces a new endpoint, `GET /users/checkout`, designed to securely fetch the necessary order and receiver details required to render the payment checkout page.

This endpoint works in tandem with `postCreateOrder` to create a seamless two-step process: first an order is created, and then its details are retrieved for final confirmation and payment.

### Implementation Details

*   **New Endpoint:** A `getCheckout` method has been added to `usersController` to handle `GET api/v1/users/checkout`.
*   **Query Parameter:** It retrieves the target order using an `order_id` that must be passed as a query parameter.
*   **Security Check:** To ensure users can only view their own orders, the database query validates that both the `order.id` and the authenticated `user_id` match a single record.
*   **Efficient Data Loading:** It uses TypeORM's `relations: ['Receiver']` option to efficiently fetch the associated receiver data in a single database query, avoiding the N+1 problem.
*   **Formatted Response:** The endpoint structures the response data to precisely match the needs of the checkout page, providing distinct `order` and `receiver` objects as per the UI design.
*   **Error Handling:** Includes robust error handling for cases where the `order_id` is missing, the order is not found, or the order does not belong to the user.

### Frontend Workflow

This new endpoint requires the following interaction flow from the client:

1.  The frontend first calls `POST api/vi/users/membership/order` to create the order.
2.  The successful response from the creation endpoint will contain the unique `order_id` for the newly created order.
3.  The frontend then immediately makes a new call to `GET api/v1/users/checkout`, passing the `order_id` it just received as a query parameter.
    *   **Example:** `GET /users/checkout?order_id=3bb9ba01-6484-45c2-8041-442b0c6474e9`

### How to Test

1.  Using an API client (like Postman), first call `POST api/vi/users/membership/order` with valid cart and receiver data. Note the `order_id` returned in the successful response.
2.  Next, call `GET /users/checkout` using the `order_id` from Step 1 as a query parameter (e.g., `?order_id=...`).
    *   **Expected Result:** You should receive a `200 OK` status and a JSON `data` object containing the `order` (with `display_id`, `total_price`) and `receiver` (with `name`, `phone`, `address`) details.
3.  To test the security, try to fetch the same order using a different user's authentication token.
    *   **Expected Result:** You should receive a `404 Not Found` error, as the `user_id` will not match.