### PR TITLE
REFACTOR: Separate Post Code from Address in Response

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -666,7 +666,8 @@ const usersController = {
         receiver: {
           name: receiver.name,
           phone: receiver.phone,
-          address: `${receiver.post_code} ${receiver.address}`,
+          post_code: receiver.post_code,
+          address: receiver.address,
         },
         cost_summary: {
           totalPrice,

--- a/entities/Order.js
+++ b/entities/Order.js
@@ -30,12 +30,15 @@ module.exports = new EntitySchema({
     receipt: {
       type: 'varchar',
       length: 10,
+      nullable: true,
     },
     paid_at: {
       type: 'timestamptz',
+      nullable: true,
     },
     discount_id: {
       type: 'smallint',
+      nullable: true,
     },
     shipping_fee: {
       type: 'integer',
@@ -47,6 +50,7 @@ module.exports = new EntitySchema({
     },
     payment_method_id: {
       type: 'smallint',
+      nullable: true,
     },
     is_ship: {
       type: 'boolean',


### PR DESCRIPTION
This PR improves the response format by separating post code from address.

Changes made:
- Change from template literal `${post_code} ${address}` to separate fields
- Return post_code and address as individual properties
- Improve data structure flexibility for frontend use

This change allows frontend to handle post code and address separately.