### PR TITLE
Fix Revenue Calculation and Order Relations

### DIFF
--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -529,6 +529,7 @@ const adminController = {
       next(error);
     }
   },
+
   async getIsShip(req, res, next) {
     try {
       const orderRepo = dataSource.getRepository('Order');
@@ -772,7 +773,7 @@ const adminController = {
     try {
       const ordersRepo = dataSource.getRepository('Order');
       const orders = await ordersRepo.find({
-        relations: ['user', 'order_link_product', 'order_link_product.product'],
+        relations: ['User', 'Order_link_product', 'Order_link_product.Product'],
         order: {
           created_at: 'DESC',
         },
@@ -783,7 +784,7 @@ const adminController = {
         const createdTime = order.created_at.toISOString().slice(0, 10).replace(/-/g, '');
 
         // 找出最早加入的商品
-        const firstProduct = order.order_link_product.sort(
+        const firstProduct = order.Order_link_product.sort(
           (a, b) => new Date(a.created_at) - new Date(b.created_at)
         )[0];
 
@@ -794,8 +795,8 @@ const adminController = {
           id: order.id,
           is_paid: order.is_paid ? 1 : 0,
           total_price: order.total_price,
-          user_email: order.user.email,
-          first_product_name: firstProduct.product.name,
+          user_email: order.User.email,
+          first_product_name: firstProduct.Product.name,
         };
       });
 
@@ -808,7 +809,6 @@ const adminController = {
       next(error);
     }
   },
-
 };
 
 module.exports = adminController;

--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -655,13 +655,20 @@ const adminController = {
       const firstDayOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
       const lastDayOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
 
+      // 將範圍轉換為 UTC 時間
+      const firstDayUTC = new Date(
+        firstDayOfMonth.getTime() - firstDayOfMonth.getTimezoneOffset() * 60000
+      );
+      const lastDayUTC = new Date(
+        lastDayOfMonth.getTime() - lastDayOfMonth.getTimezoneOffset() * 60000
+      );
+
       const orders = await orderRepo.find({
         where: {
           is_paid: true,
-          created_at: Between(firstDayOfMonth, lastDayOfMonth),
+          created_at: Between(firstDayUTC, lastDayUTC),
         },
       });
-
       const revenue = orders.reduce((sum, order) => sum + (order.total_price || 0), 0);
 
       res.status(200).json({

--- a/entities/Order.js
+++ b/entities/Order.js
@@ -103,5 +103,10 @@ module.exports = new EntitySchema({
         foreignKeyConstraintName: 'order_payment_id_fk',
       },
     },
+    Order_link_product: {
+      type: 'one-to-many',
+      target: 'Order_link_product',
+      inverseSide: 'Order',
+    },
   },
 });


### PR DESCRIPTION
## Changes Made

### 1. Fix Revenue Calculation UTC Time Handling
Fixed the date range filtering in getRevenue by properly handling UTC time conversions. This ensures accurate revenue calculations across different time zones.

### 2. Fix Order and Order_link_product Relations
Added proper bidirectional relation between Order and Order_link_product entities:
- Added one-to-many relation in Order entity
- Updated relation names in getNewOrders controller
- Ensured consistent naming across entities

## Technical Details

### Revenue Calculation
- Converted local time ranges to UTC when filtering orders
- Ensures consistent revenue calculations regardless of server timezone

### Entity Relations
- Implemented complete bidirectional relations:
  ```js
  Order_link_product: {
    type: 'one-to-many',
    target: 'Order_link_product',
    inverseSide: 'Order',
  }
  ```
- Fixed relation property names in controllers to match entity definitions

## Testing Focus
1. Revenue calculations:
   - Verify correct monthly revenue across different timezones
   - Test edge cases at month boundaries

2. Order relations:
   - Verify new orders list API works correctly
   - Confirm order-related product information displays properly
   - Validate earliest added product name shows correctly

## Impact
These changes improve the reliability of both revenue calculations and order data retrieval, ensuring consistent behavior across different environments and timezones.