### PR TITLE
feat(product): support limit param in bestSeller API and expand cart recommendations

### DIFF
--- a/controllers/products.js
+++ b/controllers/products.js
@@ -175,7 +175,7 @@ const productsController = {
       // 轉換為陣列並排序，只取前四名
       const topFourProducts = Object.values(productSales)
         .sort((a, b) => b.total_quantity - a.total_quantity)
-        .slice(0, 4)
+        .slice(0, 12)
         .map(product => ({
           id: product.product_id,
           name: product.Product.name,

--- a/controllers/products.js
+++ b/controllers/products.js
@@ -172,10 +172,11 @@ const productsController = {
         return acc;
       }, {});
 
-      // 轉換為陣列並排序，只取前四名
-      const topFourProducts = Object.values(productSales)
+      // 轉換為陣列並排序，預設只取前四名(首頁使用)，購物車調整參數 limit = 12
+      const limit = parseInt(req.query.limit) || 4;
+      const topProducts = Object.values(productSales)
         .sort((a, b) => b.total_quantity - a.total_quantity)
-        .slice(0, 12)
+        .slice(0, limit)
         .map(product => ({
           id: product.product_id,
           name: product.Product.name,
@@ -188,7 +189,7 @@ const productsController = {
 
       res.status(200).json({
         message: '成功',
-        data: topFourProducts,
+        data: topProducts,
       });
     } catch (error) {
       next(error);


### PR DESCRIPTION
## Summary

This pull request includes the following updates:

1. Expanded the number of recommended products from 4 to 12 items on the Cart page.
2. Updated the `bestSeller` API to support a configurable `limit` query parameter.
   - Default is `4` for homepage usage.
   - Cart page now fetches `?limit=12` to display 12 items dynamically.

## Impact

1.  Improves flexibility of recommendation layout across different pages.
2. Avoids hardcoded limits in frontend logic.
