### PR TITLE
Include product stock in getBestSeller API response

### DIFF
--- a/controllers/products.js
+++ b/controllers/products.js
@@ -185,6 +185,7 @@ const productsController = {
           feature: product.Product.Product_detail.feature,
           description: product.Product.Product_detail.description,
           price: product.Product.price,
+          stock: product.Product.stock,
         }));
 
       res.status(200).json({


### PR DESCRIPTION
This PR updates the getBestSeller API endpoint to include the stock value for each product.
This change enables the frontend to determine which items are sold out and display them accordingly.