### PR TITLE
Fix payment status logic in putCheckout API

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -1367,9 +1367,9 @@ const usersController = {
 
       findOrder.payment_method_id = payment_method_id;
       if (payment_method_id === 1) {
-        findOrder.is_paid = false;
-      } else {
         findOrder.is_paid = true;
+      } else {
+        findOrder.is_paid = false;
       }
 
       const cartRepo = dataSource.getRepository('Cart');


### PR DESCRIPTION
This PR updates the logic for setting is_paid in the putCheckout endpoint:

- If payment_method_id === 1, the order is marked as paid
- Otherwise, it is marked as unpaid

Ensures accurate order status depending on the selected payment method.