### PR TITLE
feat(product): add image_urls column and return multiple images in product response

### DIFF
--- a/controllers/products.js
+++ b/controllers/products.js
@@ -97,7 +97,7 @@ const productsController = {
         return;
       }
 
-      const { id, name, image_url, stock, price, Product_detail } = findProduct;
+      const { id, name, image_url, image_urls, stock, price, Product_detail } = findProduct;
       const {
         origin,
         feature,
@@ -116,6 +116,7 @@ const productsController = {
         name,
         origin,
         image_url,
+        image_urls,
         stock,
         feature,
         variety,

--- a/entities/Product.js
+++ b/entities/Product.js
@@ -36,6 +36,12 @@ module.exports = new EntitySchema({
       length: 2048,
       nullable: false,
     },
+    image_urls: {
+      type: 'text',
+      array: true,
+      nullable: false,
+      default: () => 'ARRAY[]::text[]',
+    },
     is_enable: {
       type: 'boolean',
       nullable: false,


### PR DESCRIPTION
This PR introduces backend support for multiple product images:

  - Adds a new image_urls column to the Product entity (type: text[], default: empty array)
  - Keeps the existing image_url column for backward compatibility
  - Updates the product controller to include image_urls in the response payload

This change enables the frontend to render up to 4 images by using image_urls as the primary source.